### PR TITLE
chore: ignore user-generated uploads directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# exclude user-generated files
+uploads/
+
+# Git Template of Python Below
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
### Summary
This PR updates the `.gitignore` file to exclude the `uploads/` directory, which stores user-generated files during runtime.

### Why?
- Prevents unnecessary and large file uploads from being committed to the repository.
- Keeps version control clean and focused on source code.
- Follows best practices for separating user data from codebase.

### Changes
- Appended `uploads/` to `.gitignore`

No functional changes to the application. Safe to merge.